### PR TITLE
Add device_class: power to Daily Energy

### DIFF
--- a/localbytes-plug-pm.yaml
+++ b/localbytes-plug-pm.yaml
@@ -238,6 +238,7 @@ sensor:
   # Total daily energy sensor
   - platform: total_daily_energy
     name: "Daily Energy"
+    device_class: energy
     power_id: power
     filters:
       # Multiplication factor from W to kW is 0.001


### PR DESCRIPTION
Without that, Home Assistant doesn't allow selecting this in Energy card. This is also consistent with examples on https://esphome.io/components/sensor/total_daily_energy.html