### PR TITLE
Update minimal.yaml to avoid relay toggle during OTA flash

### DIFF
--- a/minimal.yaml
+++ b/minimal.yaml
@@ -20,11 +20,12 @@ esphome:
 
   project:
     name: localbytes.plug-pm
-    version: "1.2.0"
+    version: "1.3.0"
 
 esp8266:
   board: esp01_1m
   restore_from_flash: true
+  early_pin_init: false
 
 logger:
 

--- a/minimal.yaml
+++ b/minimal.yaml
@@ -20,7 +20,7 @@ esphome:
 
   project:
     name: localbytes.plug-pm
-    version: "1.3.0"
+    version: "1.2.0"
 
 esp8266:
   board: esp01_1m


### PR DESCRIPTION
Noticed the internal relay toggles during a firmware flash. This could be dangerous if an appliance is drawing power at the time and an ESPHome update is installed OTA.

Added `early_pin_init: false` per ESPHome recommendation here: https://esphome.io/components/esp8266.html

> early_pin_init (Optional, boolean): Specifies whether pins should be initialised as early as possible to known values. Recommended value is false where switches are involved, as these will toggle when updating the firmware or when restarting the device. Defaults to true.

This has stopped the behaviour for me.