### PR TITLE
Enable IPv6 by default

### DIFF
--- a/localbytes-plug-pm.yaml
+++ b/localbytes-plug-pm.yaml
@@ -12,6 +12,9 @@ esphome:
 wifi:
   power_save_mode: high
 
+network:
+    enable_ipv6: true
+
 time:
   - platform: homeassistant
     timezone: Europe/London


### PR DESCRIPTION
Adding this is enough to get our LocalBytes plugs pulling down IPv6 addresses via SLAAC. It would be nice to enable this by default.

<img width="627" alt="image" src="https://github.com/user-attachments/assets/79d404c1-768a-4b5a-85d8-587d8061da38">


This is based on the ESPHome Network Component documentation here: https://esphome.io/components/network.html

We don't need the optional `min_ipv6_addr_count: 2` line from the documentation, as we don't want to _enforce_ IPv6, and just want it to be enabled generally when on networks that support it.