### PR TITLE
Disable restore for Total Daily Energy Sensor to prevent excessive flash writes

### DIFF
--- a/localbytes-plug-pm.yaml
+++ b/localbytes-plug-pm.yaml
@@ -240,6 +240,7 @@ sensor:
     name: "Daily Energy"
     device_class: energy
     power_id: power
+    restore: false
     filters:
       # Multiplication factor from W to kW is 0.001
       - multiply: 0.001


### PR DESCRIPTION
https://esphome.io/components/sensor/total_daily_energy.html

By default this sensor will write to flash if it's updated at an interval set by `flash_write_interval` (default every 60 seconds):
https://esphome.io/components/sensor/total_daily_energy.html

This change disables this so the sensor value will not be written and will not restore on reboot or power cycle.

The upside is so we avoid wearing out the flash memory.

The downside is if there's a reboot/power outage then the daily energy usage stats are reset - but I think it's a good trade off because:

1. We don't normally expect power outages or reboots of these devices
2. We would only lose up to one day's worth of stats which can be argued as being insignificant