### PR TITLE
Feature: Ten Second Power Cycle

### DIFF
--- a/localbytes-plug-pm.yaml
+++ b/localbytes-plug-pm.yaml
@@ -342,7 +342,7 @@ button:
   - platform: factory_reset
     name: "Restart with Factory Default Settings"
   - platform: template
-    id: 10_sec_cycle
+    id: ten_sec_cycle
     name: "Ten Second Power Cycle"
     entity_category: diagnostic
     disabled_by_default: True

--- a/localbytes-plug-pm.yaml
+++ b/localbytes-plug-pm.yaml
@@ -341,3 +341,13 @@ button:
     name: "Restart"
   - platform: factory_reset
     name: "Restart with Factory Default Settings"
+  - platform: template
+    id: 10_sec_cycle
+    name: "Ten Second Power Cycle"
+    entity_category: diagnostic
+    disabled_by_default: True
+    on_press:
+      - switch.turn_off: "relay"
+      - delay: 10000ms
+      - switch.turn_on: "relay"
+


### PR DESCRIPTION
Added a basic feature to allow for sending a command to turn off the output and then turn it back on after 10 seconds.

The purpose of this is that there are circumstances that turning the plug off may remove your ability to communicate with it so cannot turn it back on. such as the plug being on networking equipment that need power cycling or even the system hosting home assistant itself.

I have seen various people asking about reliable ways to power cycle ISP routers and such and I figured that this would be a simple feature to add to an ESPHome Plug. So I added it here.

I opted to put it into the Diagnostic section and disabled by default so its out the way but findable if someone wants it.