### PR TITLE
Fix for the firmware size issue - remove ipv6 support

### DIFF
--- a/localbytes-plug-pm.yaml
+++ b/localbytes-plug-pm.yaml
@@ -17,9 +17,6 @@ esphome:
 wifi:
   power_save_mode: high
 
-network:
-  enable_ipv6: true
-
 time:
   - platform: homeassistant
     timezone: Europe/London


### PR DESCRIPTION
This is 1 of the 2 solutions I have found to solve the firmware size issue introduced in ESPHome 2025.3.1 which means that the firmware has to be flashed to minimal before it can be updated due to the space limitations of the onboard chip.

Set as Draft PR as there should probably be some discussion as to which if either direction to take.

This reduces firmware size by removing ipv6 support.

Update: have changed to normal PR, as it seems to be popular but the other option does remain

Update 2:
I have done some maths and this change brings the firmware from approximately 7k over the size limit to approximately 50k under the size limit. (the other approach only brings it to to 8k under the limit so is still very tight)
these numbers are a big fudged but they are good enough to show that this approach is much safer long term as it gives more "wiggle room"