### PR TITLE
Alternate possible fix for the firmware size issue - change daily usage to total usage

### DIFF
--- a/localbytes-plug-pm.yaml
+++ b/localbytes-plug-pm.yaml
@@ -20,10 +20,6 @@ wifi:
 network:
   enable_ipv6: true
 
-time:
-  - platform: homeassistant
-    timezone: Europe/London
-
 api:
   services:
     - service: calibrate_voltage
@@ -265,16 +261,19 @@ sensor:
       filters:
         - lambda: return x * id(current_multiply);
 
-  # Total daily energy sensor
-  - platform: total_daily_energy
-    name: "Daily Energy"
+  # Total Energy Used
+  - platform: integration
+    name: 'Total Energy'
+    sensor: power
+    time_unit: h
+    restore: true
+    state_class: total_increasing
     device_class: energy
-    power_id: power
-    restore: false
+    unit_of_measurement: 'kWh'
+    accuracy_decimals: 3
     filters:
       # Multiplication factor from W to kW is 0.001
       - multiply: 0.001
-    unit_of_measurement: kWh
 
 # Make calibration factor data readable/set-able from home assistant
 number:


### PR DESCRIPTION
This is 1 of the 2 solutions I have found to solve the firmware size issue introduced in ESPHome 2025.3.1 which means that the firmware has to be flashed to minimal before it can be updated due to the space limitations of the onboard chip.

Set as Draft PR as there should probably be some discussion as to which if either direction to take.

This reduces firmware size by removing the time component. This would stop the daily usage tracker from being able to reset, so this has been changed to a total consumption tracker instead.

if someone needs a daily tracker this can be achieved using a utility meter helper within home assistant that tracks the total consumption sensor but resets daily.

Update:
After doing some maths, whilst this version does currently work it is still tight with storage. the wiggle room after this change is about 8k whereas the other approach is 50k. Therefore I recommend using the other method as it will future proof against hitting the same problem again down the line (at least for a while)