### PR TITLE
Add IPv6 support (again)

### DIFF
--- a/localbytes-plug-pm.yaml
+++ b/localbytes-plug-pm.yaml
@@ -17,6 +17,9 @@ esphome:
 wifi:
   power_save_mode: high
 
+network:
+  enable_ipv6: true
+  
 time:
   - platform: homeassistant
     timezone: Europe/London


### PR DESCRIPTION
This adds IPv6 Support (again)

IPv6 was originally added to the firmware by https://github.com/LocalBytes/esphome-localbytes-plug/pull/9 but then had to be removed in https://github.com/LocalBytes/esphome-localbytes-plug/pull/12 due to changes in ESPHome 2025.3.1 leading to a firmware size issue which seemed unlikely to get any better.

However recently ESPHome has undergone a lot of optimisations, and Specifically in the patch notes for [2026.1](https://esphome.io/changelog/2026.1.0/) in the section "Building forward without leaving users behind" it mentions the issues that have come over the last year or so with ESP8266 based devices and how they had stopped recommending them but there has been a change intent towards development and will treat ESP8266 optimisation as a higher priority.

With recent changes I decided to see if it was now possible to reimplement IPv6 without causing firmware size issues. and it was indeed possible (at least as of ESPHome 2026.2)

There is always the possibility that the problem may reoccur however I think it is probably safe to add this functionality back for now.