### PR TITLE
Add wifi min_auth_mode ahead of ESPHome 2026.6

### DIFF
--- a/minimal.yaml
+++ b/minimal.yaml
@@ -49,5 +49,6 @@ dashboard_import:
 wifi:
   ap:
     ssid: "${friendly_name}"
+  min_auth_mode: WPA
 
 captive_portal:

--- a/minimal.yaml
+++ b/minimal.yaml
@@ -28,6 +28,8 @@ esphome:
     name: localbytes.plug-pm
     version: "1.5.0"
 
+  min_version: 2025.11.0
+
 esp8266:
   board: esp01_1m
   restore_from_flash: true


### PR DESCRIPTION
Add min_auth_mode and set it to WPA to maintain WPA support by default for ESPHome 2026.6 onwards.

As of ESPHome [2025.11](https://esphome.io/changelog/2025.11.0/) min_auth_mode was added in https://github.com/esphome/esphome/pull/11814, This is listed as a **Breaking Change** because after a deprecation period the default for this value will change from WPA to WPA2 in ESPHome 2026.6. Whilst this is a good thing in terms of security it may cause issues for anyone still using WPA. Therefore adding this setting will ensure that WPA support is maintained when the time comes.

If users feel they would like to increase security by switching to a min of WPA2 then they will be able to do so themselves.

This will also remove the compiler warning mentioning this change when building the firmware.

NB: WPA3 is not compatible with this device and users should not try and set that as the min. I mention this as it was asked recently on the forum [HERE](https://forum.mylocalbytes.com/d/259-wpa3-compatible).