### PR TITLE
Rename services to actions in localbytes-plug-pm.yaml

### DIFF
--- a/localbytes-plug-pm.yaml
+++ b/localbytes-plug-pm.yaml
@@ -22,8 +22,8 @@ time:
     timezone: Europe/London
 
 api:
-  services:
-    - service: calibrate_voltage
+  actions:
+    - action: calibrate_voltage
       variables:
         actual_value: float
       then:
@@ -33,7 +33,7 @@ api:
             id: voltage_factor
             value: !lambda "return id(voltage_multiply);"
 
-    - service: calibrate_power
+    - action: calibrate_power
       variables:
         actual_value: float
       then:
@@ -43,7 +43,7 @@ api:
             id: power_factor
             value: !lambda "return id(power_multiply);"
 
-    - service: calibrate_current
+    - action: calibrate_current
       variables:
         actual_value: float
       then:


### PR DESCRIPTION
Rename services to actions in keeping with modern ESPHome syntax.

Whilst it is unlikely that services syntax will be depricated any time soon, to avoid any possible confusion to people reading the code it should use the newer actions syntax.

It is noted in the [Documentation](https://esphome.io/components/api/) that only actions will be used in the the documentation moving forward.