### PR TITLE
Change WiFi power save mode from high to LIGHT

### DIFF
--- a/localbytes-plug-pm.yaml
+++ b/localbytes-plug-pm.yaml
@@ -15,7 +15,7 @@ esphome:
           value: "true"
 
 wifi:
-  power_save_mode: high
+  power_save_mode: LIGHT
 
 time:
   - platform: homeassistant

--- a/minimal.yaml
+++ b/minimal.yaml
@@ -17,6 +17,7 @@ substitutions:
   disable_button_default_state: "RESTORE_DEFAULT_OFF"
 
 esphome:
+  min_version: 2026.3.1
   name: "${name}"
   friendly_name: "${friendly_name}"
 


### PR DESCRIPTION
In order to retain the current power save mode behaviour, this needs to be flipped due to the breaking change in 2026.3.1 introduced by https://github.com/esphome/esphome/pull/15029 (which flips it the other way).

Otherwise when users install a firmware built on the latest version of ESPHome, Wi-Fi connectivity becomes high-latency/potentially unstable due to the aggressive nature of the now "correctly" set HIGH mode.

Right now we have to override this in our local configs to retain previous behaviour.