### PR TITLE
Convert raw_state to get_raw_state() ahead of deprecation in ESPHome 2026.10

### DIFF
--- a/localbytes-plug-pm.yaml
+++ b/localbytes-plug-pm.yaml
@@ -28,7 +28,7 @@ api:
         actual_value: float
       then:
         - lambda: |-
-            id(voltage_multiply) = actual_value / id(voltage).raw_state;
+            id(voltage_multiply) = actual_value / id(voltage).get_raw_state();
         - number.set:
             id: voltage_factor
             value: !lambda "return id(voltage_multiply);"
@@ -38,7 +38,7 @@ api:
         actual_value: float
       then:
         - lambda: |-
-            id(power_multiply) = actual_value / id(power).raw_state;
+            id(power_multiply) = actual_value / id(power).get_raw_state();
         - number.set:
             id: power_factor
             value: !lambda "return id(power_multiply);"
@@ -48,7 +48,7 @@ api:
         actual_value: float
       then:
         - lambda: |-
-            id(current_multiply) = actual_value / id(current).raw_state;
+            id(current_multiply) = actual_value / id(current).get_raw_state();
         - number.set:
             id: current_factor
             value: !lambda "return id(current_multiply);"

--- a/minimal.yaml
+++ b/minimal.yaml
@@ -27,6 +27,8 @@ esphome:
   project:
     name: localbytes.plug-pm
     version: "1.5.0"
+  
+  min_version: 2026.4.0
 
 esp8266:
   board: esp01_1m


### PR DESCRIPTION
This change addresses issue: https://github.com/LocalBytes/esphome-localbytes-plug/issues/20

In ESPHome 2026.4.0 `raw_state` was deprecated set for removal in 2026.10.0 and is set as a compiler warning until then.

The sensor documentation is now updated to show that `get_raw_state()` is the now correct. This is also noted in the ESPHome repo PR that was merged that made the change which can be found here: https://github.com/esphome/esphome/pull/15094

Also setting the project minimum version to 2026.4.0 via the minimal file to ensure people do not try and build with older version leading to errors.

I have tested this change and it seems to be functional without any issues.